### PR TITLE
add variable to allow use of extra flags when installing ruby

### DIFF
--- a/manifests/installruby.pp
+++ b/manifests/installruby.pp
@@ -2,6 +2,7 @@ define rvm::installruby(
   $makedefault = false,
   $user,
   $rubyversion,
+  $extraflags = undef,
   $homeuser = "/home/$user",
 ){
 
@@ -13,7 +14,7 @@ define rvm::installruby(
   }->
 
   exec{ "installrubies-$user-$rubyversion":
-    command => "/bin/bash --login -c 'HOME=$homeuser && rvm install $rubyversion'",
+    command => "/bin/bash --login -c 'HOME=$homeuser && rvm install $rubyversion $extraflags'",
     unless => "/bin/bash --login -c 'rvm list |grep $rubyversion'",
     user => "$user",
     environment => ["HOME=$homeuser"],

--- a/manifests/installruby.pp
+++ b/manifests/installruby.pp
@@ -2,6 +2,7 @@ define rvm::installruby(
   $makedefault = false,
   $user,
   $rubyversion,
+  #$extraflags variable allows use of flags such as  --rubygems 1.4.2 --verify-downloads 1
   $extraflags = undef,
   $homeuser = "/home/$user",
 ){


### PR DESCRIPTION
This pull request adds a change allowing use of additional flags when installing ruby versions. In my particular case, our version of rvm couldn't find the checksum of a rubygem. 

running rvm get stable didn't resolve. But allowing us to pass the --verify-downloads 1 flag allowed the installation to proceed. Other variables, such as the version of rubygems can be passed as well.

Use in our manifest looks like this:

$extraflags = "--rubygems 1.4.2 --verify-downloads 1"
