### PR TITLE
sets rvm-requirements to specific ruby version

### DIFF
--- a/manifests/installruby.pp
+++ b/manifests/installruby.pp
@@ -7,7 +7,7 @@ define rvm::installruby(
   $homeuser = "/home/$user",
 ){
 
-  exec{ "rvm-requirements":
+  exec{ "rvm-requirements-$rubyversion":
     command => "$homeuser/.rvm/bin/rvm requirements",
     unless  => "$homeuser/.rvm/bin/rvm list |grep $rubyversion",
     require => [ Class["rvm::rubyreq"], Exec["installrvm-$user"] ],


### PR DESCRIPTION
This fixes an issue where we were trying to install multiple versions of ruby but it was failing because each ruby install was calling rvm-requirements and puppet saw that as a duplicate.
